### PR TITLE
Listen for end events

### DIFF
--- a/src/readBuffer.js
+++ b/src/readBuffer.js
@@ -3,10 +3,14 @@ export default function readBuffer(pipe, length, callback) {
     callback(null, new Buffer(0));
     return;
   }
+  let terminated = false;
   let remainingLength = length;
   const buffers = [];
   const readChunk = () => {
     const onChunk = (arg) => {
+      if (terminated) {
+        return;
+      }
       let chunk = arg;
       let overflow;
       if (chunk.length > remainingLength) {
@@ -23,10 +27,21 @@ export default function readBuffer(pipe, length, callback) {
         if (overflow) {
           pipe.unshift(overflow);
         }
+        terminated = true;
         callback(null, Buffer.concat(buffers, length));
       }
     };
+    const onEnd = () => {
+      if (terminated) {
+        return;
+      }
+      terminated = true;
+      const err = new Error(`Stream ended ${remainingLength.toString()} bytes prematurely`);
+      err.name = 'EarlyEOFError';
+      callback(err);
+    };
     pipe.on('data', onChunk);
+    pipe.on('end', onEnd);
     pipe.resume();
   };
   readChunk();

--- a/test/readBuffer.test.js
+++ b/test/readBuffer.test.js
@@ -1,0 +1,47 @@
+const stream = require('stream');
+const readBuffer = require('../dist/readBuffer');
+
+test('data is read', (done) => {
+  expect.assertions(3);
+  let eventCount = 0;
+  function read() {
+    eventCount += 1;
+    if (eventCount <= 8) {
+      return this.push(Buffer.from(eventCount.toString()));
+    }
+    return this.push(null);
+  }
+  const mockEventStream = new stream.Readable({
+    objectMode: true,
+    read,
+  });
+  function cb(err, data) {
+    expect(err).toBe(null);
+    expect(data.length).toBe(8);
+    expect(String.fromCharCode(data[0])).toBe('1');
+    done();
+  }
+  readBuffer.default(mockEventStream, 8, cb);
+});
+
+test('EOF returned for early quit', (done) => {
+  expect.assertions(2);
+  let eventCount = 0;
+  function read() {
+    eventCount += 1;
+    if (eventCount <= 5) {
+      return this.push(Buffer.from(eventCount.toString()));
+    }
+    return this.push(null);
+  }
+  const mockEventStream = new stream.Readable({
+    objectMode: true,
+    read,
+  });
+  function cb(err) {
+    expect(err.name).toBe('EarlyEOFError');
+    expect(err.message).toBe('Stream ended 3 bytes prematurely');
+    done();
+  }
+  readBuffer.default(mockEventStream, 8, cb);
+});


### PR DESCRIPTION
In the event that the read stream terminates before all of the data
has been read, the pipe will send an 'end' event. We should listen for
this event and hit the callback with it, instead of hanging forever.

Added tests to verify this. Verified the patch fixes the problem by
running the tests without the patch, observing that they timeout, then
running the tests with the patch and verifying you get an error back.