### PR TITLE
Fix EventEmitter leak

### DIFF
--- a/dist/readBuffer.js
+++ b/dist/readBuffer.js
@@ -30,6 +30,7 @@ function readBuffer(pipe, length, callback) {
       if (remainingLength === 0) {
         pipe.pause();
         pipe.removeListener('data', onChunk);
+        pipe.removeListener('end', onEnd);
         if (overflow) {
           pipe.unshift(overflow);
         }


### PR DESCRIPTION
Failing to remove the 'end' listener means we keep attaching listeners
to the pipes, which are long lived. We need to remove the listeners
when we're done with the pipes.

Updates sourcegraph/sourcegraph#310.